### PR TITLE
change of source for FreeBSD 13.0

### DIFF
--- a/templates/manual/freebsd-13.0.json
+++ b/templates/manual/freebsd-13.0.json
@@ -7,7 +7,7 @@
     "public_netadp_service": "public",
     "vm_type": "a1.small",
     "ssh_name": "my-ssh",
-    "mirror": "https://download.freebsd.org/ftp/releases/amd64/13.0-RELEASE/base.txz",
+    "mirror": "http://ftp.freebsd.org/pub/FreeBSD/releases/amd64/13.0-RELEASE/base.txz",
     "image_description": "{\"arch\":\"x64\",\"distro\":\"freebsd\",\"release\":\"13.0\",\"edition\":\"server\",\"codename\":\"stable\",\"recommended\":{\"disk\":{\"size\":10}}}",
     "state_timeout": "10m"
   },


### PR DESCRIPTION
Old source not longer provides FreeBSD mirror, had to updated to a new source.

